### PR TITLE
ci: remove the requirements files to avoid conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,18 @@ update:
 	@echo "- Updating dependencies -"
 	@echo "-------------------------"
 
+	rm requirements.txt
+	touch requirements.txt
 	pip-compile -Ur --allow-unsafe
+
+	rm docs/requirements.txt
+	touch docs/requirements.txt
 	pip-compile -Ur --allow-unsafe docs/requirements.in --output-file docs/requirements.txt
+
+	rm requirements-dev.txt
+	touch requirements-dev.txt
 	pip-compile -Ur --allow-unsafe requirements-dev.in --output-file requirements-dev.txt
+
 	pip install -r requirements-dev.txt
 
 	@echo ""


### PR DESCRIPTION
<!--
Thank you for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is, try to link it with open issues -->
pip-compile used the existent requirements.txt content to pin the
versions of some packages creating conflicts. Not anymore

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
